### PR TITLE
fix potential bug of PR #248

### DIFF
--- a/src/manifold.jl
+++ b/src/manifold.jl
@@ -328,7 +328,7 @@ function init_manifold_projection(IIP::Val{iip}, manifold, autodiff, manifold_ja
     JJᵀfact = safe_factorize!(JJᵀ)
 
     return SingleFactorizeManifoldProjectionCache{iip}(
-        manifold, p, abstol, maxiters, ũ, JJᵀfact, ũ, λ, gu,
+        manifold, p, abstol, maxiters, ũ, JJᵀfact, similar(ũ), λ, gu,
         true, J, JJᵀ, manifold_jacobian, autodiff, di_extras)
 end
 
@@ -337,6 +337,7 @@ function SciMLBase.solve!(cache::SingleFactorizeManifoldProjectionCache{iip}) wh
     ũ = cache.ũ
     gu = cache.gu_cache
 
+    copyto!(cache.u_cache, ũ)
     internal_solve_failed = true
 
     if cache.gu_cache !== nothing


### PR DESCRIPTION
ũ and u_cache were sharing the same memory, and in my use case, the bug that https://github.com/SciML/DiffEqCallbacks.jl/pull/248 closed is not completely fixed. The integration works, however there was a big discontinuity. This new fix really solves the problem.